### PR TITLE
refactor: remove duplicate functions in Voter

### DIFF
--- a/test/ExternalBribes.t.sol
+++ b/test/ExternalBribes.t.sol
@@ -62,11 +62,18 @@ contract ExternalBribesTest is BaseTest {
         // ve
         VELO.approve(address(escrow), TOKEN_1);
         escrow.create_lock(TOKEN_1, 365 * 86400);
+
         vm.startPrank(address(owner2));
         VELO.approve(address(escrow), TOKEN_1);
         escrow.create_lock(TOKEN_1, 365 * 86400);
-        vm.warp(block.timestamp + 1);
         vm.stopPrank();
+
+        vm.startPrank(address(owner3));
+        VELO.approve(address(escrow), TOKEN_1);
+        escrow.create_lock(TOKEN_1, 365 * 86400);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 1);
     }
 
     function testCanClaimExternalBribe() public {
@@ -146,6 +153,129 @@ contract ExternalBribesTest is BaseTest {
         xbribe.getRewardForOwner(2, rewards);
         post = LR.balanceOf(address(owner2));
         assertEq(post - pre, TOKEN_1 / 2);
+    }
+    
+    function testCanClaimExternalBribeProRataAfterManyWeeks() public {
+        // fwd half a week
+        vm.warp(block.timestamp + 1 weeks / 2);
+
+        // create a bribe with some rewards
+        LR.approve(address(xbribe), TOKEN_1 * 10);
+        xbribe.notifyRewardAmount(address(LR), TOKEN_1);
+        assertEq(LR.balanceOf(address(xbribe)), TOKEN_1);
+
+        uint256 initialBalance2 = LR.balanceOf(address(owner2));
+        uint256 initialBalance3 = LR.balanceOf(address(owner3));
+
+        // owner2 and owner3 vote
+        address[] memory pools = new address[](1);
+        pools[0] = address(pair);
+        uint256[] memory weights = new uint256[](1);
+        weights[0] = 10000;
+
+        vm.prank(address(owner2));
+        voter.vote(2, pools, weights);
+
+        vm.prank(address(owner3));
+        voter.vote(3, pools, weights);
+
+        // fwd 1 week
+        vm.warp(block.timestamp + 1 weeks);
+
+        // hand out some more rewards
+        xbribe.notifyRewardAmount(address(LR), TOKEN_1);
+        assertEq(LR.balanceOf(address(xbribe)), TOKEN_1 * 2);
+
+        // vote again
+        vm.prank(address(owner2));
+        voter.vote(2, pools, weights);
+
+        vm.prank(address(owner3));
+        voter.vote(3, pools, weights);
+
+        // fwd 3 weeks
+        vm.warp(block.timestamp + 3 weeks);
+    
+        // claim bribe
+        address[] memory rewards = new address[](1);
+        rewards[0] = address(LR);
+
+        vm.prank(address(voter));
+        xbribe.getRewardForOwner(2, rewards);
+        uint256 post = LR.balanceOf(address(owner2));
+        assertEq(post - initialBalance2, TOKEN_1); // fail here: post - initialBalance2 = 500000000000000000
+
+        vm.prank(address(voter));
+        xbribe.getRewardForOwner(3, rewards);
+        post = LR.balanceOf(address(owner3));
+        assertEq(post - initialBalance3, TOKEN_1); // fail here: post - initialBalance2 = 500000000000000000
+    }
+    
+    function testCanClaimExternalBribeProRataEveryWeek() public {
+        // fwd half a week
+        vm.warp(block.timestamp + 1 weeks / 2);
+
+        // create a bribe with some rewards
+        LR.approve(address(xbribe), TOKEN_1 * 10);
+        xbribe.notifyRewardAmount(address(LR), TOKEN_1);
+        assertEq(LR.balanceOf(address(xbribe)), TOKEN_1);
+
+        uint256 initialBalance2 = LR.balanceOf(address(owner2));
+        uint256 initialBalance3 = LR.balanceOf(address(owner3));
+
+        // owner2 and owner3 vote
+        address[] memory pools = new address[](1);
+        pools[0] = address(pair);
+        uint256[] memory weights = new uint256[](1);
+        weights[0] = 10000;
+
+        vm.prank(address(owner2));
+        voter.vote(2, pools, weights);
+
+        vm.prank(address(owner3));
+        voter.vote(3, pools, weights);
+
+        // fwd 1 week
+        vm.warp(block.timestamp + 1 weeks);
+
+        // claim bribe
+        address[] memory rewards = new address[](1);
+        rewards[0] = address(LR);
+        
+        vm.prank(address(voter));
+        xbribe.getRewardForOwner(2, rewards);
+        uint256 post = LR.balanceOf(address(owner2));
+        assertEq(post - initialBalance2, TOKEN_1 / 2);
+
+        vm.prank(address(voter));
+        xbribe.getRewardForOwner(3, rewards);
+        post = LR.balanceOf(address(owner3));
+        assertEq(post - initialBalance3, TOKEN_1 / 2);
+
+        // hand out some more rewards
+        xbribe.notifyRewardAmount(address(LR), TOKEN_1);
+        assertEq(LR.balanceOf(address(xbribe)), TOKEN_1);
+
+        // vote again
+        vm.prank(address(owner2));
+        voter.vote(2, pools, weights);
+
+        vm.prank(address(owner3));
+        voter.vote(3, pools, weights);
+
+        // fwd 1 week
+        vm.warp(block.timestamp + 1 weeks);
+
+        // claim bribe
+        vm.prank(address(voter));
+        xbribe.getRewardForOwner(2, rewards);
+        post = LR.balanceOf(address(owner2));
+        assertEq(post - initialBalance2, TOKEN_1);
+
+        vm.prank(address(voter));
+        xbribe.getRewardForOwner(3, rewards);
+        post = LR.balanceOf(address(owner3));
+        assertEq(post - initialBalance3, TOKEN_1);
     }
 
     function testCanClaimExternalBribeStaggered() public {

--- a/test/KillGauges.t.sol
+++ b/test/KillGauges.t.sol
@@ -189,6 +189,6 @@ contract KillGaugesTest is BaseTest {
     voter.killGauge(address(gauge));
 
     // should be able to claim from gauge2, just not from gauge
-    voter.distro();
+    voter.distribute();
   }
 }

--- a/test/Pair.t.sol
+++ b/test/Pair.t.sol
@@ -515,7 +515,7 @@ contract PairTest is BaseTest {
         VELO.approve(address(voter), PAIR_1);
         voter.notifyRewardAmount(PAIR_1);
         voter.updateAll();
-        voter.distro();
+        voter.distribute();
     }
 
     function bribeClaimRewards() public {
@@ -621,7 +621,7 @@ contract PairTest is BaseTest {
         uint256 claimable = voter.claimable(address(gauge));
         VELO.approve(address(staking), claimable);
         staking.notifyRewardAmount(claimable);
-        voter.distro();
+        voter.distribute();
         vm.warp(block.timestamp + 1800);
         vm.roll(block.number + 1);
     }
@@ -738,7 +738,6 @@ contract PairTest is BaseTest {
         reward[0] = address(DAI);
         rewards[0] = reward;
         voter.claimBribes(bribes_, rewards, 1);
-        voter.claimFees(bribes_, rewards, 1);
         uint256 supply = escrow.totalSupply();
         assertGt(supply, 0);
         vm.warp(block.timestamp + 4*365*86400);
@@ -815,7 +814,7 @@ contract PairTest is BaseTest {
         address[] memory gauges = new address[](1);
         gauges[0] = address(gauge);
         voter.updateFor(gauges);
-        voter.distro();
+        voter.distribute();
         address[][] memory tokens = new address[][](1);
         address[] memory token = new address[](1);
         token[0] = address(VELO);


### PR DESCRIPTION
- rename several variables
- `claimFees` is duplicate with `claimBribes`
- `distro` is duplicate with `distribute`