### PR TITLE
feat: support variable lock amount in IDO

### DIFF
--- a/contracts/TokenSale.sol
+++ b/contracts/TokenSale.sol
@@ -19,10 +19,9 @@ contract TokenSale is Ownable, ReentrancyGuard {
 
     IERC20 public immutable salesToken;
     IVotingEscrow public immutable ve;
-    uint256 public immutable tokensToSell;
-    uint256 public immutable wlRate;
-    uint256 public immutable publicRate;
-    uint256 public immutable maxBonusPercentage;
+    uint public immutable tokensToSell;
+    uint public immutable conversionRate; // 1 ETH = `conversionRate` * 1,000,000 tokens
+    uint public immutable maxBonusPercentage;
 
     Status public status;
     
@@ -30,17 +29,17 @@ contract TokenSale is Ownable, ReentrancyGuard {
 
     // Total tokens sold, not including bonus
     // After the sale concludes, `tokensToSell - totalTokensSold` amount of tokens will be burned if there are any left
-    uint256 public totalTokensSold;
+    uint public totalTokensSold;
 
     // Tokens reserved in the contract for sales + max bonus
     // Only unreserved tokens can be withdrawn by team after sale ends
-    uint256 public reservedTokens;
+    uint public reservedTokens;
 
-    mapping(address => uint256) public claimableAmounts; // amount of tokens claimable by user
-    mapping(address => uint256) public wlCommitments; // amount of ETH committed in WL sale
+    mapping(address => uint) public claimableAmounts; // amount of tokens claimable by user
+    mapping(address => uint) public wlEthCommitments; // amount of ETH committed in WL sale by user
+    mapping(address => uint) public totalEthCommitments; // amount of ETH committed in WL + public sale by user
 
-    uint internal constant MAX_LOCK_WEEKS = 52; // max lock is 1 year
-    uint internal constant MIN_LOCK_WEEKS = 4;
+    uint internal constant RATE_PRECISION = 10**6; // 1,000,000, precision for ETH to token conversion rate
 
     // mapping from lock time (in months) to bonus percentage
     // we treat 1 month = 4 weeks for simplicity
@@ -49,15 +48,9 @@ contract TokenSale is Ownable, ReentrancyGuard {
     constructor(
         IERC20 _salesToken,
         IVotingEscrow _ve,
-        uint256 _wlRate, // whitelist sale ETH to token conversion rate
-        uint256 _publicRate, // public sale ETH to token conversion rate
-        uint256 _tokensToSell
+        uint _conversionRate,
+        uint _tokensToSell
     ) {
-        require(
-            _wlRate >= _publicRate,
-            "WL price must not be higher than public"
-        );
-
         // token must be 18 decimals, otherwise we'll have problems with ETH conversion rate
         require(_salesToken.decimals() == 18, "Token must be 18 decimals");
 
@@ -66,8 +59,7 @@ contract TokenSale is Ownable, ReentrancyGuard {
         salesToken = _salesToken;
         ve = _ve;
         tokensToSell = _tokensToSell;
-        wlRate = _wlRate;
-        publicRate = _publicRate;
+        conversionRate = _conversionRate;
         status = Status.NOT_STARTED;
         bonusPercentages[1] = 6; // 1 mo lock = 6% bonus in veVS
         bonusPercentages[2] = 12; // 2 mo lock = 12% bonus
@@ -105,7 +97,7 @@ contract TokenSale is Ownable, ReentrancyGuard {
         status = Status.FINISHED_UNCLAIMABLE;
 
         // transfer ETH to owner
-        uint256 remainingETH = address(this).balance;
+        uint remainingETH = address(this).balance;
         (bool success, ) = msg.sender.call{value: remainingETH}("");
         require(success, "Failed to transfer ether");
     }
@@ -120,7 +112,7 @@ contract TokenSale is Ownable, ReentrancyGuard {
 
     // user address + capAmount must match merkle proof
     // capAmount is the max amount of ETH user can commit for WL sale
-    function commitWhitelist(uint256 capAmount, bytes32[] calldata merkleProof) external payable nonReentrant {
+    function commitWhitelist(uint capAmount, bytes32[] calldata merkleProof) external payable nonReentrant {
         require(msg.value > 0, "No ETH sent");
         require(capAmount > 0, "Cap amount must be > 0");
         require(status == Status.WHITELIST_ROUND, "Not whitelist round");
@@ -128,14 +120,15 @@ contract TokenSale is Ownable, ReentrancyGuard {
         // Verify the merkle proof
         bytes32 node = keccak256(bytes.concat(keccak256(abi.encode(msg.sender, capAmount))));
         require(MerkleProof.verify(merkleProof, merkleRoot, node), "Invalid proof");
-        require(wlCommitments[msg.sender] + msg.value <= capAmount, "Individual cap reached");
+        require(wlEthCommitments[msg.sender] + msg.value <= capAmount, "Individual cap reached");
 
-        uint256 tokenAmount = msg.value * wlRate / 10**6;
+        uint tokenAmount = msg.value * conversionRate / RATE_PRECISION;
 
         require(totalTokensSold + tokenAmount <= tokensToSell, "Global cap reached");
 
         claimableAmounts[msg.sender] += tokenAmount;
-        wlCommitments[msg.sender] += msg.value;
+        wlEthCommitments[msg.sender] += msg.value;
+        totalEthCommitments[msg.sender] += msg.value;
         totalTokensSold += tokenAmount;
         reservedTokens += ((tokenAmount * (100 + maxBonusPercentage)) / 100);
     }
@@ -143,40 +136,39 @@ contract TokenSale is Ownable, ReentrancyGuard {
     function commitPublic() external payable nonReentrant {
         require(status == Status.PUBLIC_ROUND, "Not public round");
 
-        uint256 tokenAmount = msg.value * publicRate / 10**6;
+        uint tokenAmount = msg.value * conversionRate / RATE_PRECISION;
         require(totalTokensSold + tokenAmount <= tokensToSell, "Global cap reached");
         claimableAmounts[msg.sender] += tokenAmount;
+        totalEthCommitments[msg.sender] += msg.value;
         totalTokensSold += tokenAmount;
         reservedTokens += ((tokenAmount * (100 + maxBonusPercentage)) / 100);
     }
 
-    function claim() external nonReentrant {
+    // user can optionally lock their tokens for 1/2/4/8/12 months to get bonus in liquid $VS
+    // if lockMonths == 0, no lock
+    // bonus amount = lockAmount * bonusPercentage / 100
+    function claimAndLock(uint lockAmount, uint lockMonths) external nonReentrant {
         require(status == Status.FINISHED_CLAIMABLE, "Cannot claim yet");
         require(claimableAmounts[msg.sender] > 0, "Nothing to claim");
+        require(lockMonths == 0 || bonusPercentages[lockMonths] > 0, "Must lock 1/2/4/8/12 months");
 
-        uint256 amt = claimableAmounts[msg.sender];
+        uint amt = claimableAmounts[msg.sender];
+        require(amt >= lockAmount, "Invalid lock amount");
         claimableAmounts[msg.sender] = 0;
-        _safeTransfer(address(salesToken), msg.sender, amt);
+        uint bonus = 0;
 
-        // decrease the amount of reserved tokens
-        reservedTokens -= (amt + amt * maxBonusPercentage / 100);
-    }
+        if (lockAmount > 0 && lockMonths > 0) {
+            bonus = getBonusAmount(lockAmount, lockMonths);
+            
+            // convert lock duration to seconds
+            uint lockDurationSeconds = lockMonths * 4 weeks;
 
-    function claimAndLock(uint lockMonths) external nonReentrant {
-        require(status == Status.FINISHED_CLAIMABLE, "Cannot claim yet");
-        require(claimableAmounts[msg.sender] > 0, "Nothing to claim");
-        require(bonusPercentages[lockMonths] > 0, "Must lock 1/2/4/8/12 months");
+            // mint veVS of lockAmount
+            ve.create_lock_for(lockAmount + bonus, lockDurationSeconds, msg.sender);
+        }
 
-        // convert lock duration to seconds
-        uint256 lockDurationSeconds = lockMonths * 4 weeks;
-
-        uint256 amt = claimableAmounts[msg.sender];
-        claimableAmounts[msg.sender] = 0;
-        ve.create_lock_for(amt, lockDurationSeconds, msg.sender);
-
-        // transfer bonus tokens
-        uint256 bonus = amt * bonusPercentages[lockMonths] / 100;
-        _safeTransfer(address(salesToken), msg.sender, bonus);
+        // transfer liquid tokens
+        _safeTransfer(address(salesToken), msg.sender, amt - lockAmount);
 
         // decrease the amount of reserved tokens
         reservedTokens -= (amt + amt * maxBonusPercentage / 100);
@@ -185,12 +177,12 @@ contract TokenSale is Ownable, ReentrancyGuard {
     receive() external payable {}
 
     function emergencyWithdrawETH() external onlyOwner {
-        uint256 remainingETH = address(this).balance;
+        uint remainingETH = address(this).balance;
         msg.sender.call{value: remainingETH}("");
     }
 
     function emergencyWithdrawTokens() external onlyOwner {
-        uint256 allTokens = salesToken.balanceOf(address(this));
+        uint allTokens = salesToken.balanceOf(address(this));
         _safeTransfer(address(salesToken), msg.sender, allTokens);
     }
 
@@ -202,16 +194,30 @@ contract TokenSale is Ownable, ReentrancyGuard {
 
     // View functions
 
-    function getClaimableAmount(address _user) public view returns (uint256) {
+    function getClaimableAmount(address _user) public view returns (uint) {
         return claimableAmounts[_user];
     }
 
-    function getWlCommitment(address _user) public view returns (uint256) {
-        return wlCommitments[_user];
+    function getWlCommitment(address _user) public view returns (uint) {
+        return wlEthCommitments[_user];
     }
 
-    function getRemainingTokens() public view returns (uint256) {
+    function getTotalCommitment(address _user) public view returns (uint) {
+        return totalEthCommitments[_user];
+    }
+
+    function getBonusAmount(uint lockAmount, uint lockMonths) public view returns (uint) {
+        return lockAmount * bonusPercentages[lockMonths] / 100;
+    }
+
+    // returns the unsold tokens + unallocated bonus in the contract
+    function getRemainingTokens() public view returns (uint) {
         return salesToken.balanceOf(address(this)) - reservedTokens;
+    }
+
+    // returns the unsold tokens (not including any remaining bonus)
+    function getUnsoldTokens() public view returns (uint) {
+        return tokensToSell - totalTokensSold;
     }
 
     function getStatus() public view returns (uint) {
@@ -220,14 +226,14 @@ contract TokenSale is Ownable, ReentrancyGuard {
     
     // Helper functions
 
-    function _safeTransfer(address token, address to, uint256 value) internal {
+    function _safeTransfer(address token, address to, uint value) internal {
         require(token.code.length > 0);
         (bool success, bytes memory data) =
         token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
         require(success && (data.length == 0 || abi.decode(data, (bool))));
     }
 
-    function _safeTransferFrom(address token, address from, address to, uint256 value) internal {
+    function _safeTransferFrom(address token, address from, address to, uint value) internal {
         require(token.code.length > 0);
         (bool success, bytes memory data) =
         token.call(abi.encodeWithSelector(IERC20.transferFrom.selector, from, to, value));

--- a/test/TokenSale.t.sol
+++ b/test/TokenSale.t.sol
@@ -15,17 +15,15 @@ contract TokenSaleTest is BaseTest {
         address[] memory owners = new address[](1);
         uint256[] memory amounts = new uint256[](1);
         owners[0] = address(this);
-        amounts[0] = 20000e18;
+        amounts[0] = 39000e18;
         mintVelo(owners, amounts);
         
         VeArtProxy artProxy = new VeArtProxy();
         ve = new VotingEscrow(address(VELO), address(artProxy));
 
-        // WL rate 1E = 20000 Token
-        // public rate 1E = 10000 Token
-        // cap 15000 Token
-        // max 30% bonus
-        sale = new TokenSale(IERC20(address(VELO)), IVotingEscrow(address(ve)), 20000 * 1e6, 10000 * 1e6, 15000e18);
+        // rate 1E = 20000 Token
+        // cap 30000 Token (1.5 E)
+        sale = new TokenSale(IERC20(address(VELO)), IVotingEscrow(address(ve)), 20000 * 1e6, 30000e18);
 
         // merkle root is generated in example_proof.json
         sale.setMerkleRoot(0x8d8edd611c4eda08c1a22a6a9b6c3eadc6e4d2e5c7a475268b5be06aaa269de1);
@@ -33,11 +31,11 @@ contract TokenSaleTest is BaseTest {
         // mock ether balance
         vm.deal(user1, 1 ether);
         vm.deal(user2, 1 ether);
-        vm.deal(user3, 1 ether);
+        vm.deal(user3, 2 ether);
     }
 
     function testNoBonus() public {
-        VELO.approve(address(sale), 19500e18); // approve extra 30% bonus
+        VELO.approve(address(sale), 39000e18); // approve extra 30% bonus
 
         // test: status is correct
         assertEq(sale.getStatus(), 0);
@@ -70,7 +68,7 @@ contract TokenSaleTest is BaseTest {
 
         vm.stopPrank();
 
-        // user 2 WL amount = 0.25E
+        // user 2 WL amount = 0.25E, commit amount = 0.1E
         vm.startPrank(user2);
         bytes32[] memory proof2 = new bytes32[](2);
         proof2[0] = 0x7ea9b5357dd8c851ccc7bbd872f3a8f62b9725cf3da0e8431afe31d6544a73e1;
@@ -99,15 +97,19 @@ contract TokenSaleTest is BaseTest {
 
         // test: user 3 commits public round
         sale.commitPublic{value: 0.8 ether}();
-        assertEq(sale.getClaimableAmount(user3), 8000e18);
+        assertEq(sale.getClaimableAmount(user3), 16000e18);
 
-        // test: 15000e18 tokens sold out, cannot commit anymore
+        // test: till now, users have committed 1.15E in total == 23000 Token
+        assertEq(sale.totalTokensSold(), 23000e18);
+        assertEq(sale.getUnsoldTokens(), 7000e18);
+
+        // test: cannot commit 0.8 eth again
         vm.expectRevert("Global cap reached");
-        sale.commitPublic{value: 0.1 ether}();
+        sale.commitPublic{value: 0.8 ether}();
 
         // test: cannot claim before end
         vm.expectRevert("Cannot claim yet");
-        sale.claim();
+        sale.claimAndLock(0, 0);
         vm.stopPrank();
 
         // owner calls finish
@@ -123,7 +125,7 @@ contract TokenSaleTest is BaseTest {
 
         // test: still cannot claim before "enableClaim"
         vm.expectRevert("Cannot claim yet");
-        sale.claim();
+        sale.claimAndLock(0, 0);
         vm.stopPrank();
 
         sale.enableClaim();
@@ -133,22 +135,22 @@ contract TokenSaleTest is BaseTest {
 
         // test: user1 claims
         vm.prank(user1);
-        sale.claim();
+        sale.claimAndLock(0, 0);
         assertEq(VELO.balanceOf(user1), 5000e18);
 
         // test: user2 claims
         vm.prank(user2);
-        sale.claim();
+        sale.claimAndLock(0, 0);
         assertEq(VELO.balanceOf(user2), 2000e18);
 
         // test: user3 claims
         vm.startPrank(user3);
-        sale.claim();
-        assertEq(VELO.balanceOf(user3), 8000e18);
+        sale.claimAndLock(0, 0);
+        assertEq(VELO.balanceOf(user3), 16000e18);
 
         // test: cannot claim twice
         vm.expectRevert("Nothing to claim");
-        sale.claim();
+        sale.claimAndLock(0, 0);
         vm.stopPrank();
 
         balanceBefore = VELO.balanceOf(address(this));
@@ -156,14 +158,14 @@ contract TokenSaleTest is BaseTest {
         balanceAfter = VELO.balanceOf(address(this));
 
         // test: 30% bonus tokens are returned because no one got bonus 
-        assertEq(balanceAfter - balanceBefore, 15000e18 * 30 / 100);
+        assertEq(balanceAfter - balanceBefore, 30000e18 * 30 / 100 + sale.getUnsoldTokens());
 
         // test: totalTokensSold is correct
-        assertEq(sale.totalTokensSold(), 15000e18);
+        assertEq(sale.totalTokensSold(), 23000e18);
     }
 
     function testBonus() public {
-        VELO.approve(address(sale), 19500e18); // approve extra 30% bonus
+        VELO.approve(address(sale), 39000e18); // approve extra 30% bonus
         sale.start();
 
         // user 1 WL amount = 0.25E
@@ -181,7 +183,7 @@ contract TokenSaleTest is BaseTest {
         // user 2 commits public round
         vm.prank(user2);
         sale.commitPublic{value: 1 ether}();
-        assertEq(sale.getClaimableAmount(user2), 10000e18);
+        assertEq(sale.getClaimableAmount(user2), 20000e18);
 
         // owner calls finish and enable claim
         uint256 balanceBefore = address(this).balance;
@@ -193,12 +195,12 @@ contract TokenSaleTest is BaseTest {
         // test: ETH is transferred to owner
         assertEq(balanceAfter - balanceBefore, 1.25 ether);
 
-        // user1 claims and locks 1 year (12 months)
+        // user1 claims and locks 40% (2000e18) for 1 year (12 months)
         vm.prank(user1);
-        sale.claimAndLock(12);
+        sale.claimAndLock(2000e18, 12);
 
-        // test: 30% liquid token bonus, and 1 veNFT
-        assertEq(VELO.balanceOf(user1), 5000e18 * 30 / 100);
+        // test: user1 will have 3000 unlocked, and 1 veNFT
+        assertEq(VELO.balanceOf(user1), 3000e18);
         assertEq(ve.ownerOf(1), address(user1));
         assertEq(ve.balanceOf(address(user1)), 1);
 
@@ -206,42 +208,42 @@ contract TokenSaleTest is BaseTest {
         balanceBefore = VELO.balanceOf(address(this));
         sale.withdrawRemainingTokens();
         balanceAfter = VELO.balanceOf(address(this));
-        uint expectedReturned = 19500e18 - 5000e18 * 130 / 100 - 10000e18 * 130 / 100;
+        uint expectedReturned = 39000e18 - 20000e18 * 130 / 100 - 3000e18 - 2000e18 * 130 / 100; // (2000e18 * 30 / 100 is the bonus but in veVS)
         assertEq(balanceAfter - balanceBefore, expectedReturned);
 
-        // user2 claims and locks 4 months
+        // user2 claims and locks 100% for 4 months
         vm.startPrank(user2);
 
         // test: cannot lock anything other than 1/2/4/8/12 months
         vm.expectRevert("Must lock 1/2/4/8/12 months");
-        sale.claimAndLock(13);
+        sale.claimAndLock(20000e18, 13);
         vm.expectRevert("Must lock 1/2/4/8/12 months");
-        sale.claimAndLock(9);
+        sale.claimAndLock(20000e18, 9);
         vm.expectRevert("Must lock 1/2/4/8/12 months");
-        sale.claimAndLock(0);
+        sale.claimAndLock(20000e18, 3);
 
         // lock 4 months
-        sale.claimAndLock(4);
+        sale.claimAndLock(20000e18, 4);
 
         // test: 18% liquid token bonus, and 1 veNFT
-        assertEq(VELO.balanceOf(user2), 10000e18 * 18 / 100);
+        assertEq(VELO.balanceOf(user2), 0);
         assertEq(ve.ownerOf(2), address(user2));
         assertEq(ve.balanceOf(address(user2)), 1);
 
         // test: cannot claim and lock twice
         vm.expectRevert("Nothing to claim");
-        sale.claimAndLock(4);
+        sale.claimAndLock(20000e18, 4);
         vm.stopPrank();
 
         balanceBefore = VELO.balanceOf(address(this));
         sale.withdrawRemainingTokens();
         balanceAfter = VELO.balanceOf(address(this));
 
-        // test: owner can claim remaining
-        expectedReturned = 19500e18 - 5000e18 - 10000e18 - 5000e18 * 30 / 100 - 10000e18 * 18 / 100;
+        // test: owner can claim remaining unallocated bonus
+        expectedReturned = 20000e18 * 12 / 100;
         assertEq(balanceAfter - balanceBefore, expectedReturned);
 
         // test: totalTokensSold is correct
-        assertEq(sale.totalTokensSold(), 15000e18);
+        assertEq(sale.totalTokensSold(), 25000e18);
     }
 }


### PR DESCRIPTION
- support variable lock amount
- bonus is given in veVS
- `claimAndLock` will be the only entry point to claim. No locking means lock time == 0
- use the same conversion rate for WL and public round
- use `uint` for consistency