### PR TITLE
add support for Dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Node runtime as a parent image
+FROM node:18
+
+# Install curl and other dependencies
+RUN apt-get update && apt-get install -y curl
+
+# Install Foundry
+RUN curl -L https://foundry.paradigm.xyz | bash
+
+# Install bun
+RUN curl -fsSL https://bun.sh/install | bash
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Make port 3000 available to the world outside this container
+EXPOSE 3000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Solidity Smart Contract Dev Container",
+  "dockerFile": "Dockerfile",
+  "forwardPorts": [3000],
+  "postCreateCommand": "foundryup && bun install && forge compile"
+}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
 # VeSync
+[![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/veSync/contracts)
 
 This repo contains the contracts for VeSync, a ve(3,3) DEX on zkSync Era inspired by Velodrome Finance and Solidly.
+
 ## Testing
 
 This repo uses both Foundry (for Solidity testing) and Hardhat (for deployment).


### PR DESCRIPTION
You can use "open in codespaces" to seamlessly develop smart contracts in the cloud. Or after merging, you can click the badge in the readme to develop in the cloud.


<img width="1718" alt="Screenshot 2023-10-05 at 14 31 03@2x" src="https://github.com/veSync/contracts/assets/22890026/cce9330d-9009-45db-8cea-37148956e61b">
